### PR TITLE
Allow following symlinks for dependencies when stat(1)-ing them.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,13 @@ $(BUILD)/%.ffs: $(EDK2_OUTPUT_DIR)/%.efi
 $(BUILD)/%.ffs:
 	$(create-ffs)
 
-ROM_SIZE ?= `stat -c"%s" $(ROM)`
+ROM_SIZE ?= `stat -Lc"%s" $(ROM)`
 
 $(BUILD)/%.rom:
 	cat > $@.tmp $^
 	@if [ `stat -c"%s" $@.tmp` -ne $(ROM_SIZE) ]; then \
 		printf >&2 "%s: Wrong output size 0x%x != expected 0x%x\n" \
-			$@ `stat -c'%s' $@.tmp` `stat -c'%s' $(ROM)` ; \
+			$@ `stat -c'%s' $@.tmp` `stat -Lc'%s' $(ROM)` ; \
 		exit 1; \
 	fi
 	mv $@.tmp $@


### PR DESCRIPTION
The current top level Makefile cannot work with a symlinked rom file. I cannot get the point NOT to allow original rom file being accessed via symlinks, so I would like to fix it.